### PR TITLE
fix(serializer): add support for marker tags in xliff serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is the [@ngx-translate/polyfill](https://github.com/ngx-translate/i18n-polyfill) with additional support for marker tags, i.e. ```<mkr>```.
+
 # @ngx-translate/i18n-polyfill [![Travis Status](https://travis-ci.org/ngx-translate/i18n-polyfill.svg?branch=master)](https://travis-ci.org/ngx-translate/i18n-polyfill) [![npm version](https://img.shields.io/npm/v/@ngx-translate/i18n-polyfill.svg)](https://www.npmjs.com/package/@ngx-translate/i18n-polyfill)
 
 Extraction tool + service to add support for code translations in Angular using the same implementation that is used for [template translations](https://angular.io/guide/i18n#template-translations).

--- a/lib/src/serializers/xliff2.ts
+++ b/lib/src/serializers/xliff2.ts
@@ -20,6 +20,7 @@ const _XMLNS = "urn:oasis:names:tc:xliff:document:2.0";
 const _DEFAULT_SOURCE_LANG = "en";
 const _PLACEHOLDER_TAG = "ph";
 const _PLACEHOLDER_SPANNING_TAG = "pc";
+const _MARKER_TAG = 'mrk';
 const _XLIFF_TAG = "xliff";
 const _SOURCE_TAG = "source";
 const _TARGET_TAG = "target";
@@ -262,6 +263,8 @@ class XmlToI18n implements ml.Visitor {
           );
         }
         break;
+      case _MARKER_TAG:
+          return [].concat(...ml.visitAll(this, el.children));
       default:
         this._addError(el, `Unexpected tag`);
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ngx-translate/i18n-polyfill",
   "description": "A speculative polyfill to support i18n code translations in Angular",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "scripts": {
     "prebuild": "del-cli dist",

--- a/test/serializers/xliff.spec.ts
+++ b/test/serializers/xliff.spec.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {xliffDigest, xliffLoadToI18n, xliffLoadToXml, xliffWrite} from "../../lib/src/serializers/xliff";
-import {MessageBundle} from "../../lib/extractor/src/message-bundle";
+import { xliffDigest, xliffLoadToI18n, xliffLoadToXml, xliffWrite } from "../../lib/src/serializers/xliff";
+import { MessageBundle } from "../../lib/extractor/src/message-bundle";
 
 const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -43,7 +43,7 @@ const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
       <trans-unit id="d7fa2d59aaedcaa5309f13028c59af8c85b8c49d" datatype="html">
         <source><x id="LINE_BREAK" ctype="lb"/><x id="TAG_IMG" ctype="image"/><x id="START_TAG_DIV" ctype="x-div"/><x id="CLOSE_TAG_DIV" ctype="x-div"/></source>
         <target><x id="START_TAG_DIV" ctype="x-div"/><x id="CLOSE_TAG_DIV" ctype="x-div"/><x id="TAG_IMG" ctype="image"/><x id="LINE_BREAK" ctype="lb"/></target>
-      </trans-unit>            
+      </trans-unit>
       <trans-unit id="empty target" datatype="html">
         <source><x id="LINE_BREAK" ctype="lb"/><x id="TAG_IMG" ctype="image"/><x id="START_TAG_DIV" ctype="x-div"/><x id="CLOSE_TAG_DIV" ctype="x-div"/></source>
         <target/>
@@ -65,6 +65,20 @@ const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 lines</source>
         <target>multi
 lignes</target>
+      </trans-unit>
+      <trans-unit id="mrk-test">
+        <source>First sentence.</source>
+        <seg-source>
+          <invalid-tag>Should not be parsed</invalid-tag>
+        </seg-source>
+        <target>Translated <mrk mtype="seg" mid="1">first sentence</mrk>.</target>
+      </trans-unit>
+      <trans-unit id="mrk-test2">
+        <source>First sentence. Second sentence.</source>
+        <seg-source>
+          <invalid-tag>Should not be parsed</invalid-tag>
+        </seg-source>
+        <target>Translated <mrk mtype="seg" mid="1"><mrk mtype="seg" mid="2">first</mrk> sentence</mrk>.</target>
       </trans-unit>
     </body>
   </file>
@@ -191,6 +205,18 @@ describe("Xliff serializer", () => {
 lines</source>
         <target>multi
 lignes</target>
+      </trans-unit><trans-unit id="mrk-test">
+        <source>First sentence.</source>
+        <seg-source>
+          <invalid-tag>Should not be parsed</invalid-tag>
+        </seg-source>
+        <target>Translated <mrk mtype="seg" mid="1">first sentence</mrk>.</target>
+      </trans-unit><trans-unit id="mrk-test2">
+        <source>First sentence. Second sentence.</source>
+        <seg-source>
+          <invalid-tag>Should not be parsed</invalid-tag>
+        </seg-source>
+        <target>Translated <mrk mtype="seg" mid="1"><mrk mtype="seg" mid="2">first</mrk> sentence</mrk>.</target>
       </trans-unit>
       <trans-unit id="9161da7236814a71c5fec94eb42161651f6b4967" datatype="html">
         <source>This is a test message <x id="ICU" equiv-text="{sex, select, other {...}}"/></source>

--- a/test/serializers/xliff2.spec.ts
+++ b/test/serializers/xliff2.spec.ts
@@ -117,6 +117,24 @@ lines</source>
 lignes</target>
       </segment>
     </unit>
+    <unit id="mrk-test">
+     <notes>
+      <note id="n1" appliesTo="target">Please check the translation for 'namespace'. On also can use 'espace de nom',but I think most technical manuals use the English term.</note>
+     </notes>
+     <segment>
+      <source>You use your own namespace.</source>
+      <target>Vous pouvez utiliser votre propre <mrk id="m1" type="comment" ref="#n1">namespace</mrk>.</target>
+     </segment>
+    </unit>
+    <unit id="mrk-test2">
+     <notes>
+      <note id="n1" appliesTo="target">Please check the translation for 'namespace'. On also can use 'espace de nom',but I think most technical manuals use the English term.</note>
+     </notes>
+     <segment>
+      <source>You use your own namespace.</source>
+      <target>Vous pouvez utiliser <mrk id="m1" type="comment" ref="#n1">votre propre <mrk id="m2" type="comment" ref="#n1">namespace</mrk></mrk>.</target>
+     </segment>
+    </unit>
   </file>
 </xliff>
 `;
@@ -294,6 +312,22 @@ lines</source>
         <target>multi
 lignes</target>
       </segment>
+    </unit><unit id="mrk-test">
+     <notes>
+      <note id="n1" appliesTo="target">Please check the translation for &apos;namespace&apos;. On also can use &apos;espace de nom&apos;,but I think most technical manuals use the English term.</note>
+     </notes>
+     <segment>
+      <source>You use your own namespace.</source>
+      <target>Vous pouvez utiliser votre propre <mrk id="m1" type="comment" ref="#n1">namespace</mrk>.</target>
+     </segment>
+    </unit><unit id="mrk-test2">
+     <notes>
+      <note id="n1" appliesTo="target">Please check the translation for &apos;namespace&apos;. On also can use &apos;espace de nom&apos;,but I think most technical manuals use the English term.</note>
+     </notes>
+     <segment>
+      <source>You use your own namespace.</source>
+      <target>Vous pouvez utiliser <mrk id="m1" type="comment" ref="#n1">votre propre <mrk id="m2" type="comment" ref="#n1">namespace</mrk></mrk>.</target>
+     </segment>
     </unit>
     <unit id="5980763297918130233">
       <notes>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We do not support marker tags that are specified in the XLIFF spec

Issue Number: [#21078](https://github.com/angular/angular/issues/21078)


## What is the new behavior?
We support those tags (those are "inert" tags used by translation tools, we just need to ignore them and parse their contents)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR is based on [#21250](https://github.com/angular/angular/pull/21250).